### PR TITLE
Add support for keyup

### DIFF
--- a/PTHotKey/PTHotKey+ShortcutRecorder.h
+++ b/PTHotKey/PTHotKey+ShortcutRecorder.h
@@ -18,9 +18,9 @@
                             action:(SEL)anAction;
 
 + (PTHotKey *)hotKeyWithIdentifier:(id)anIdentifier
-						  keyCombo:(NSDictionary *)aKeyCombo
-							target:(id)aTarget
-							action:(SEL)anAction
-					   keyUpAction:(SEL)aKeyUpAction;
+                          keyCombo:(NSDictionary *)aKeyCombo
+                            target:(id)aTarget
+                            action:(SEL)anAction
+                        keyUpAction:(SEL)aKeyUpAction;
 
 @end

--- a/PTHotKey/PTHotKey+ShortcutRecorder.m
+++ b/PTHotKey/PTHotKey+ShortcutRecorder.m
@@ -27,17 +27,17 @@
 }
 
 + (PTHotKey *)hotKeyWithIdentifier:(id)anIdentifier
-						  keyCombo:(NSDictionary *)aKeyCombo
-							target:(id)aTarget
-							action:(SEL)anAction
-					   keyUpAction:(SEL)aKeyUpAction
-{
-	PTHotKey *newHotKey = [PTHotKey hotKeyWithIdentifier:anIdentifier
-											 keyCombo:aKeyCombo
-											   target:aTarget
-											   action:anAction];
-	[newHotKey setKeyUpAction:aKeyUpAction];
-	return newHotKey;
+                          keyCombo:(NSDictionary *)aKeyCombo
+                            target:(id)aTarget
+                            action:(SEL)anAction
+                       keyUpAction:(SEL)aKeyUpAction
+{				
+    PTHotKey *newHotKey = [PTHotKey hotKeyWithIdentifier:anIdentifier
+                                                keyCombo:aKeyCombo
+                                                  target:aTarget
+                                                  action:anAction];
+    [newHotKey setKeyUpAction:aKeyUpAction];
+    return newHotKey;
 }
 
 @end

--- a/PTHotKey/PTHotKey.h
+++ b/PTHotKey/PTHotKey.h
@@ -19,7 +19,7 @@
 	PTKeyCombo*		mKeyCombo;
 	id				mTarget;
 	SEL				mAction;
-	SEL             mKeyUpAction;
+    SEL             mKeyUpAction;
 
 	UInt32		    mCarbonHotKeyID;
 	EventHotKeyRef	mCarbonEventHotKeyRef;

--- a/PTHotKey/PTHotKey.m
+++ b/PTHotKey/PTHotKey.m
@@ -113,7 +113,7 @@
 
 - (SEL)keyUpAction
 {
-	return mKeyUpAction;
+    return mKeyUpAction;
 }
 
 - (UInt32)carbonHotKeyID
@@ -145,8 +145,8 @@
 
 - (void)uninvoke
 {
-	if ([mTarget respondsToSelector:mKeyUpAction])
-		[mTarget performSelector: mKeyUpAction withObject: self];
+    if ([mTarget respondsToSelector:mKeyUpAction])
+        [mTarget performSelector: mKeyUpAction withObject: self];
 }
 
 @end

--- a/PTHotKey/PTHotKeyCenter.m
+++ b/PTHotKey/PTHotKeyCenter.m
@@ -202,7 +202,7 @@ static PTHotKeyCenter *_sharedHotKeyCenter = nil;
 
 - (void)_hotKeyUp: (PTHotKey*)hotKey
 {
-	[hotKey uninvoke];
+    [hotKey uninvoke];
 }
 
 - (void)sendEvent: (NSEvent*)event


### PR DESCRIPTION
Unless I'm missing something there appears to be no support for keyup, only keydown for hot keys.  PTHotKey implements all the hard stuff except the private _hotKeyUp method does nothing and offers no way to supply an action to call on key up.

This change completes keyUp support, adds a keyUpAction to PTHotKey, and adds an additional convenience class method for creating a hot key and supplying a keyUp action.
