### PR TITLE
Silence an unused variable warning

### DIFF
--- a/Library/SRRecorderControl.m
+++ b/Library/SRRecorderControl.m
@@ -40,7 +40,7 @@ static const CGFloat _SRRecorderControlHeight = 25.0;
 
 static const CGFloat _SRRecorderControlBottomShadowHeightInPixels = 1.0;
 
-static const CGFloat _SRRecorderControlBaselineOffset = 5.0;
+__attribute__((unused)) static const CGFloat _SRRecorderControlBaselineOffset = 5.0;
 
 
 // Clear Button Layout Constants


### PR DESCRIPTION
_SRRecorderControlBaselineOffset is commented out. This will silences the warning but keeps the variable, in case it needs to be used again in the future.