### PR TITLE
Send actions via NSApp so responder chain is used

### DIFF
--- a/PTHotKey/PTHotKey.m
+++ b/PTHotKey/PTHotKey.m
@@ -143,13 +143,16 @@
 
 - (void)invoke
 {
-	[mTarget performSelector: mAction withObject: self];
+	if(mAction) {
+    		[NSApp sendAction:mAction to:mTarget from:self];
+    	}
 }
 
 - (void)uninvoke
 {
-    if ([mTarget respondsToSelector:mKeyUpAction])
-        [mTarget performSelector: mKeyUpAction withObject: self];
+	if(mKeyUpAction) {
+    		[NSApp sendAction:mKeyUpAction to:mTarget from:self];
+    	}
 }
 
 @end


### PR DESCRIPTION
Use [NSApp sendAction:to:from:] in invoke and uninvoke so nil-targeted actions get sent up the responder chain.