### PR TITLE
Update PTHotKeyCenter.m

### DIFF
--- a/PTHotKey/PTHotKeyCenter.m
+++ b/PTHotKey/PTHotKeyCenter.m
@@ -250,8 +250,9 @@ static PTHotKeyCenter *_sharedHotKeyCenter = nil;
 	if( err )
 		return err;
 
+    	if( hotKeyID.signature != 'PTHk' )
+        	return eventNotHandledErr;
 
-	NSAssert( hotKeyID.signature == 'PTHk', @"Invalid hot key id" );
 	NSAssert( hotKeyID.id != 0, @"Invalid hot key id" );
 
 	hotKey = [self _hotKeyForCarbonHotKeyID:hotKeyID];


### PR DESCRIPTION
Check to see if the hotkey signature is PTHk and return eventNotHandledErr if it's not one of ours, rather than throwing an assertion exception. Hotkey events can be generated by other hotkeys installed on the system.