### PR TITLE
Fills in summary attribute for podspec, required by Cocoapods 1.x

### DIFF
--- a/ShortcutRecorder.podspec
+++ b/ShortcutRecorder.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'ShortcutRecorder'
   s.homepage = "https://github.com/Kentzo/ShortcutRecorder"
-  s.summary = ""
+  s.summary = "The only user interface control to record shortcuts."
   s.version      = '2.13'
   s.source       = { :git => 'git://github.com/Kentzo/ShortcutRecorder.git',
                      :branch => 'master' }


### PR DESCRIPTION
This resolves a fatal error when running pod install and using Cocoapods 1.x