### PR TITLE
Add core subspec to podspec to allow for installing without PTHotKey

### DIFF
--- a/ShortcutRecorder.podspec
+++ b/ShortcutRecorder.podspec
@@ -5,15 +5,19 @@ Pod::Spec.new do |s|
   s.version = '2.16'
   s.source = { :git => 'git://github.com/Kentzo/ShortcutRecorder.git', :branch => 'master' }
   s.author = { 'Ilya Kulakov' => 'kulakov.ilya@gmail.com' }
-  s.source_files = 'Library/*.{h,m}'
   s.frameworks = 'Carbon', 'Cocoa'
-  s.resource_bundles = { "ShortcutRecorder" => ['Resources/*.lproj', 'Resources/*.png'] }
-  s.requires_arc = true
-  s.prefix_header_file = 'Library/Prefix.pch'
   s.platform = :osx, "10.6"
+
+  s.subspec 'Core' do |core|
+    core.source_files = 'Library/*.{h,m}'
+    core.resource_bundles = { "ShortcutRecorder" => ['Resources/*.lproj', 'Resources/*.png'] }
+    core.requires_arc = true
+    core.prefix_header_file = 'Library/Prefix.pch'
+  end
 
   s.subspec 'PTHotKey' do |hotkey|
     hotkey.source_files = 'PTHotKey/*.{h,m}'
     hotkey.requires_arc = false
+    hotkey.dependency 'ShortcutRecorder/Core'
   end
 end


### PR DESCRIPTION
Tested with https://github.com/larsblumberg/shortcutrecorder-cocoapods-demo, corresponding Podfile: https://github.com/larsblumberg/shortcutrecorder-cocoapods-demo/blob/master/Podfile

(Replaces pull request https://github.com/Kentzo/ShortcutRecorder/pull/60)