### PR TITLE
Add summary to podspec

### DIFF
--- a/ShortcutRecorder.podspec
+++ b/ShortcutRecorder.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = 'ShortcutRecorder'
   s.homepage = 'https://github.com/Kentzo/ShortcutRecorder'
-  s.summary = ''
+  s.summary = 'The only user interface control to record shortcuts. For Mac OS X 10.6+, 64bit'
   s.version = '2.17'
   s.source = { :git => 'git://github.com/Kentzo/ShortcutRecorder.git', :branch => 'master' }
   s.author = { 'Ilya Kulakov' => 'kulakov.ilya@gmail.com' }


### PR DESCRIPTION
This is required by CocoaPods 1.0, otherwise the Pod can't be used:

```
Pre-downloading: `ShortcutRecorder` from `https://github.com/Kentzo/ShortcutRecorder`, tag `2.17`
[!] The `ShortcutRecorder` pod failed to validate due to 1 error:
    - WARN  | attributes: Missing required attribute `license`.
    - ERROR | attributes: Missing required attribute `summary`.
    - WARN  | license: Missing license type.
    - WARN  | source: Git sources should specify a tag.
    - WARN  | github_sources: Github repositories should use an `https` link.
```