### PR TITLE
Add a flag to store an empty dictionary for deleted shortcuts.

### DIFF
--- a/Library/SRRecorderControl.h
+++ b/Library/SRRecorderControl.h
@@ -136,6 +136,13 @@ IB_DESIGNABLE
 @property (nonatomic, getter=isEnabled) IBInspectable BOOL enabled;
 
 /*!
+    Determines whether we store an empty dictionary for deleted shortcuts.
+
+    @discussion Defaults to NO.
+ */
+@property IBInspectable BOOL storesEmptyValueForNoShortcut;
+
+/*!
     Determines whether recording is in process.
  */
 @property (nonatomic, readonly) BOOL isRecording;

--- a/Library/SRRecorderControl.m
+++ b/Library/SRRecorderControl.m
@@ -117,6 +117,7 @@ typedef NS_ENUM(NSUInteger, _SRRecorderControlButtonTag)
     _enabled = YES;
     _allowedModifierFlags = SRCocoaModifierFlagsMask;
     _requiredModifierFlags = 0;
+    _storesEmptyValueForNoShortcut = NO;
     _mouseTrackingButtonTag = _SRRecorderControlInvalidButtonTag;
     _snapBackButtonToolTipTag = NSIntegerMax;
 
@@ -202,6 +203,10 @@ typedef NS_ENUM(NSUInteger, _SRRecorderControlButtonTag)
     // to handle NSNull here and convert it into nil.
     if ((NSNull *)newObjectValue == [NSNull null])
         newObjectValue = nil;
+
+    if (newObjectValue == nil && self.storesEmptyValueForNoShortcut) {
+        newObjectValue = @{};
+    }
 
     _objectValue = [newObjectValue copy];
     [self propagateValue:_objectValue forBinding:NSValueBinding];


### PR DESCRIPTION
When the flag `storesEmptyValueForNoShortcut` of `SRRecorderControl` is set to `YES`, then an empty dictionary is stored instead of `nil` for shortcuts set to none. I may be the only person who needs this distinction, i.e. "does not exist" vs. "set to none". Please feel free to reject the PR if you think this option is not useful for others 😀.