### PR TITLE
Add a flag to store an empty dictionary for deleted shortcuts.

### DIFF
--- a/Library/SRRecorderControl.h
+++ b/Library/SRRecorderControl.h
@@ -112,6 +112,13 @@ NS_SWIFT_NAME(RecorderControl)
 @property (nonatomic, getter=isEnabled) IBInspectable BOOL enabled;
 
 /*!
+    Determines whether we store an empty dictionary for deleted shortcuts.
+
+    @discussion Defaults to NO.
+ */
+@property IBInspectable BOOL storesEmptyValueForNoShortcut;
+
+/*!
     Determines whether recording is in process.
  */
 @property (nonatomic, readonly) BOOL isRecording;

--- a/Library/SRRecorderControl.m
+++ b/Library/SRRecorderControl.m
@@ -110,6 +110,7 @@ typedef NS_ENUM(NSUInteger, _SRRecorderControlButtonTag)
     _enabled = YES;
     _allowedModifierFlags = SRCocoaModifierFlagsMask;
     _requiredModifierFlags = 0;
+    _storesEmptyValueForNoShortcut = NO;
     _mouseTrackingButtonTag = _SRRecorderControlInvalidButtonTag;
     _snapBackButtonToolTipTag = NSIntegerMax;
 
@@ -218,6 +219,10 @@ typedef NS_ENUM(NSUInteger, _SRRecorderControlButtonTag)
         NSLog(@"WARNING: Shortcut Recroder 2 compatibility mode enabled. Getters of objectValue and NSValueBinding will return an instance of NSDictionary.");
         _isCompatibilityModeEnabled = YES;
         newObjectValue = [SRShortcut shortcutWithDictionary:(NSDictionary *)newObjectValue];
+    }
+
+    if (newObjectValue == nil && self.storesEmptyValueForNoShortcut) {
+        newObjectValue = @{};
     }
 
     _objectValue = [newObjectValue copy];


### PR DESCRIPTION
When the flag storesEmptyValueForNoShortcut of SRRecorderControl is set to YES, then an empty dictionary is stored instead of nil for shortcuts set to none. I may be the only person who needs this distinction, i.e. "does not exist" vs. "set to none". Please feel free to reject the PR if you think this option is not useful for others 😀.