### PR TITLE
Fix warning about STGlobalShortcutMonitor dispatchQueue property

### DIFF
--- a/Library/SRShortcutAction.h
+++ b/Library/SRShortcutAction.h
@@ -330,7 +330,7 @@ NS_SWIFT_NAME(GlobalShortcutMonitor)
 
  @seealso DISPATCH_BLOCK_NO_QOS_CLASS
  */
-@property dispatch_queue_t dispatchQueue;
+@property (strong, nonnull) dispatch_queue_t dispatchQueue;
 
 /*!
  Enable system-wide shortcut monitoring.


### PR DESCRIPTION
This PR fixes the following warnings reported about the `dispatchQueue` property on `STGlobalShortcutMonitor`.

https://github.com/Kentzo/ShortcutRecorder/blob/c0b3a415c887a1b49c2cd4c497bfa8543eb60132/Library/SRShortcutAction.h#L327

1. No 'assign', 'retain', or 'copy' attribute is specified - 'assign' is assumed
2. Default property attribute 'assign' not appropriate for object

