### PR TITLE
SRAXGlobalShortcutMonitor: Avoid using NSEvent from the CGEventTap ha…

### DIFF
--- a/Sources/ShortcutRecorder/include/ShortcutRecorder/SRCommon.h
+++ b/Sources/ShortcutRecorder/include/ShortcutRecorder/SRCommon.h
@@ -24,6 +24,9 @@ NS_SWIFT_NAME(CarbonModifierFlagsMask)
 static const UInt32 SRCarbonModifierFlagsMask = cmdKey | optionKey | shiftKey | controlKey;
 
 
+NS_SWIFT_NAME(CoreGraphicsModifierFlagsMask)
+static const CGEventFlags SRCoreGraphicsModifierFlagsMask = kCGEventFlagMaskCommand | kCGEventFlagMaskAlternate | kCGEventFlagMaskShift | kCGEventFlagMaskControl;
+
 /*!
  Dawable unicode characters for key codes that do not have appropriate constants in Carbon and Cocoa.
 
@@ -299,6 +302,26 @@ NS_INLINE UInt32 SRCocoaToCarbonFlags(NSEventModifierFlags aCocoaFlags)
         carbonFlags |= shiftKey;
 
     return carbonFlags;
+}
+
+NS_SWIFT_NAME(coreGraphicsToCocoaFlags(_:))
+NS_INLINE NSEventModifierFlags SRCoreGraphicsToCocoaFlags(CGEventFlags aCoreGraphicsFlags)
+{
+    NSEventModifierFlags cocoaFlags = 0;
+
+    if (aCoreGraphicsFlags & kCGEventFlagMaskCommand)
+        cocoaFlags |= NSEventModifierFlagCommand;
+
+    if (aCoreGraphicsFlags & kCGEventFlagMaskAlternate)
+        cocoaFlags |= NSEventModifierFlagOption;
+
+    if (aCoreGraphicsFlags & kCGEventFlagMaskControl)
+        cocoaFlags |= NSEventModifierFlagControl;
+
+    if (aCoreGraphicsFlags & kCGEventFlagMaskShift)
+        cocoaFlags |= NSEventModifierFlagShift;
+
+    return cocoaFlags;
 }
 
 

--- a/Sources/ShortcutRecorder/include/ShortcutRecorder/SRShortcutAction.h
+++ b/Sources/ShortcutRecorder/include/ShortcutRecorder/SRShortcutAction.h
@@ -198,6 +198,10 @@ typedef NS_CLOSED_ENUM(NSUInteger, SRKeyEventType)
 
 @interface NSEvent (SRShortcutAction)
 
++ (SRKeyEventType)SR_keyEventTypeForEventType:(NSEventType)anEventType
+                                      keyCode:(unsigned short)aKeyCode
+                                modifierFlags:(NSEventModifierFlags)aModifierFlags;
+
 /*!
  Keyboard event type as recognized by the shortcut recorder.
 


### PR DESCRIPTION
…ndler

NSEvent seems to depend on being used from the main thread, which is unncessary limiting for the monitor.

Refs #129