### PR TITLE
fix: cache image key equal

### DIFF
--- a/Sources/ShortcutRecorder/SRRecorderControlStyle.m
+++ b/Sources/ShortcutRecorder/SRRecorderControlStyle.m
@@ -502,7 +502,7 @@ NSUserInterfaceLayoutDirection SRRecorderControlStyleComponentsLayoutDirectionTo
 
     return [self.identifier isEqual:anObject.identifier] &&
         [self.components isEqual:anObject.components] &&
-        [self.name isEqual:anObject];
+        [self.name isEqual:anObject.name];
 }
 
 - (id)copyWithZone:(NSZone *)aZone


### PR DESCRIPTION
The incorrect comparison of `name` causes styles' images always miss cache.

Although it's not in the scope of the PR, I think `_SRRecorderControlStyleResourceLoaderCacheImageKey` is unnecessary as we can use `[NSString stringWithFormat:@"%@-%@%@", aStyle.identifier, aStyle.effectiveComponents.stringRepresentation, aName]` as key.