### PR TITLE
fix: cache image key equal

### DIFF
--- a/Sources/ShortcutRecorder/SRRecorderControlStyle.m
+++ b/Sources/ShortcutRecorder/SRRecorderControlStyle.m
@@ -502,7 +502,7 @@ NSUserInterfaceLayoutDirection SRRecorderControlStyleComponentsLayoutDirectionTo
 
     return [self.identifier isEqual:anObject.identifier] &&
         [self.components isEqual:anObject.components] &&
-        [self.name isEqual:anObject];
+        [self.name isEqual:anObject.name];
 }
 
 - (id)copyWithZone:(NSZone *)aZone
@@ -845,7 +845,10 @@ NSUserInterfaceLayoutDirection SRRecorderControlStyleComponentsLayoutDirectionTo
 
         @synchronized (self)
         {
-            NSString *key = [NSString stringWithFormat:@"%@-%@%@", aStyle.identifier, aStyle.effectiveComponents.stringRepresentation, aName];
+            __auto_type key = [_SRRecorderControlStyleResourceLoaderCacheImageKey new];
+            key.identifier = [aStyle.identifier copy];
+            key.components = [aStyle.effectiveComponents copy];
+            key.name = [aName copy];
             NSArray *imageNameCache = [self->_cache objectForKey:key];
 
             if (!imageNameCache)

--- a/Sources/ShortcutRecorder/SRRecorderControlStyle.m
+++ b/Sources/ShortcutRecorder/SRRecorderControlStyle.m
@@ -845,10 +845,7 @@ NSUserInterfaceLayoutDirection SRRecorderControlStyleComponentsLayoutDirectionTo
 
         @synchronized (self)
         {
-            __auto_type key = [_SRRecorderControlStyleResourceLoaderCacheImageKey new];
-            key.identifier = [aStyle.identifier copy];
-            key.components = [aStyle.effectiveComponents copy];
-            key.name = [aName copy];
+            NSString *key = [NSString stringWithFormat:@"%@-%@%@", aStyle.identifier, aStyle.effectiveComponents.stringRepresentation, aName];
             NSArray *imageNameCache = [self->_cache objectForKey:key];
 
             if (!imageNameCache)


### PR DESCRIPTION
The incorrect comparison of `name` causes styles' images always miss cache.

Although it's not in the scope of the PR, I think `_SRRecorderControlStyleResourceLoaderCacheImageKey` is unnecessary as we can use `[NSString stringWithFormat:@"%@-%@%@", aStyle.identifier, aStyle.effectiveComponents.stringRepresentation, aName]` as key, for [example](https://github.com/ninjaprox/ShortcutRecorder/pull/2).